### PR TITLE
Fixed wrong worldgourd-logo

### DIFF
--- a/worldgourd-logo.svg
+++ b/worldgourd-logo.svg
@@ -1,1 +1,234 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 615.05 143.11"><defs><style>.cls-1{fill:none;}.cls-2{fill:#2d2d2d;}.cls-3{clip-path:url(#clip-path);}.cls-4{fill:url(#New_Gradient_Swatch_copy);}.cls-5{mask:url(#mask);}.cls-6{opacity:0.1;}.cls-7{fill:url(#New_Gradient_Swatch_copy-2);}.cls-8{mask:url(#mask-2);}.cls-9{fill:url(#New_Gradient_Swatch_copy-3);}.cls-10{mask:url(#mask-3);}.cls-11{fill:#fff;}.cls-12{filter:url(#luminosity-invert);}</style><clipPath id="clip-path"><path class="cls-1" d="M78.54,138.1c-3.85,3.85-10.45,3.45-14.33-.42L5.07,78.54a9.85,9.85,0,0,1-.07-14L63.63,6c3.85-3.85,11.25-4.68,15.13-.8l59,59c3.88,3.88,3.63,11.13-.23,15Z"/></clipPath><linearGradient id="New_Gradient_Swatch_copy" x1="71.56" y1="3.86" x2="71.56" y2="141.19" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#006bff"/><stop offset="1" stop-color="#004dff"/></linearGradient><filter id="luminosity-invert" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB"><feColorMatrix values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0"/></filter><mask id="mask" x="29.59" y="-2.48" width="83" height="42" maskUnits="userSpaceOnUse"><g class="cls-12"><image width="83" height="42" transform="translate(29.59 -2.48)" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFMAAAAqCAYAAADPn2cJAAAACXBIWXMAAAsSAAALEgHS3X78AAAGoklEQVRoQ+2bWXObQBCEGxDLcsjR6eT//7vEcbmcyDE3eVD11jBaST50PXiqKKILlo+entnFCQAM+IqTRHjsC1/x9pgc+8I1IwxDRFEEAAiCAH3fu+0W42ZhTiYTWGthjHFA27ZF0zQoyxJt2x45wuXjJmHGcYyiKJDn+Qhm13Wo6xovLy/YbDZomubIkS4bNwczSRJ8+/ZtBDMMt9be9z3qukaSJDDG4Pn5GWVZHjni5eKmYFprMZ/PcXd3h+l0iizLEMfxSJlN0yBJEsRxjDAM8fT0dDNAbwamtRar1Qrz+RzT6RRFUcBaiyRJRsqsqsq9T9CPj494fX09cobzx03ATNMUq9UKy+USs9kM0+kUeZ7DWutVZlmWDuZkMkEYhnh4eLg60KvDzLIM6/Uay+USi8Vi5JcynYGtMpum2VFnGIYO6MvLy5Ezni+uCjPLMtzf32O9XmOxWGA2m+Hu7g5FUSDLsqMwqcwoihBFEYIgwK9fv64G9Gow8zzH9+/fsVqtnFfOZjMURYGiKJCm6VGYxhgkSeKABkHggG42myMjOH1cBSZB3t/fY7lcOq+UKU6Y9ERgC7NtW5Rl6dKcfShhhmGIIAgwDMPFFXpxmHme48ePH1iv1zteOZ1OXUskZz+yALVtizRNXREyxjhl0juB7fTz58+f+Pv376HhnDQuCpMg6ZMEOZ/PnSqZ4tITtTLZa/pAMtX5m2EYLpbyF4MpQcr0plfKwpOmKYwxDlYQBAC2YNq2Hc2C4jh27ROhEugwbFcXL6XQi8DUINlTEiRTPM/zUYpLSMA2zdlr1nU9quZSmQB29pdQ6Nlh7gMp05sznizLXEtEmNIHufwmYUpF+mACuJhCzwpTVm16pATJ2Q5hsoLLmQ+rNLCF0nXdTmrr9GYMw+A2vu77/mxV/mwwsyxzINlLMrUlSO2VcprI4iNhsggRIj1Vf88XUqHnSPmzwCTI9Xq9k9bSIyVImd5siWSKM/q+dxClGiVIqUTeAG7y9b9//3bG/pk4OUw5RZQgZ7PZCKT2SRYdVnCpNBm+NkiDPASRewAnn3qeFGaapg6iVCIhUolylsOeUk4NtRp1BEHgKjxjH8S2bV0X0HXd6BkSv3uq1aaTwbTW7i0yhJjnuYNorXUeqRX51pBAj0H0Ae26DsMw4OHh4SQpfxKYXNhdLBYupaUS8zzfUaNuut8LkhGG2yeYcRyPWqc0TdG2rZsxyb0EK2/CZ1fsPw3TWrvTN/Kxg0xpLkxob5RN90eClVxWd2MM2raFtXYEVkLVYIdhwO/fvz8F9FMwkyQZtToSopzNSIi67ZF95EdDzsfDMHTHj+PYeXFd10jT1DX8hEmgVOfj4yOqqjp2Sm98GKYxZm9hkRCPLUicImRf6QNLK+F4rLXIsswpVKq073s8PT19COiHYMZx7CBKkNIPZfMtZyq6jem6zr2/rx06FLLosPUhXAmWFqChUq3SBgj0vc/l3w0zjmPXJ3JxgtWZ00C9AEFAsopybZKf6dXyQ1D19JBFR6YtVeYDK9VqrUVVVQ6qLE5//vx5F9B3wZxMJsjz/CBELk7oKSDhUQEsOPJzpqZWqJ4mcs/CIW+O9kQJlsciVN50+qq11v2Wv9tsNm/+U5w3w4yiCFmWjSD65tEMDZEApUrbtt2xAl4o4F9G41436F3XOYAEUpYlqqryFhuGzwKste77fb+ddr4F6JtgRlHkTFtDlKnpA1hVlVeF2g58xWlfuyS9UcKUyqdCq6oabbLg8Di+gmWMgbXWwX99fUXXdd7xMI7CZDr4WhupGF5IXdcjlTINeZGEKCu8hikVrL1TqpLH3geUCvVBresadV2PFMjzyX61abaPSLpu+0djh4AehEmQvqeAvKtahTqNm6aBMQZVVY18VTfsPK5UOuCHyb2u5NI7pUK5EWJVVc4C+J60AILluIwxo4ImbULGXpi8MAlQp7IuJBosZzoaYByPV8hl1ZcprkEyOAad6hKo9FCtVKlWKlT6qwTHsVCt8rw6vDClh2hYhwAyfSU8mc4yrWkFMq0lUI7DFzrVJVyCkJXcp9Z9gOVGsARHqLxxGuhemNIPOTipTJ6cSpOK0/B8RUaD9MHkWGTINJfj03uqVO4JWO6leiVwvecxfHwYOzA1RN4ZqtIHR9rBIWhvUeIhkAx5AT6VcuPYtbdqwNoe+Fqrm+/viwDY/a8rvouTfqY3Hxyf2uSmzyP3vrEwfF7lU6v+t7YD32v9md58x5bhhfkVH4uPLSJ+hTf+A45XAcRn3tf4AAAAAElFTkSuQmCC"/></g></mask><linearGradient id="New_Gradient_Swatch_copy-2" x1="71.55" y1="3.86" x2="71.55" y2="141.19" xlink:href="#New_Gradient_Swatch_copy"/><mask id="mask-2" x="-2.41" y="45.52" width="148" height="51" maskUnits="userSpaceOnUse"><g class="cls-12"><image width="148" height="51" transform="translate(-2.41 45.52)" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJQAAAAzCAYAAABxJSGCAAAACXBIWXMAAAsSAAALEgHS3X78AAAInklEQVR4Xu1d63arvA4cY65J3/9BdxpuBnN+5IwRhiRA0n609azFSgMJYGk0koWztwIwICDgTYiefSAgYAviZx/4Diil3Cs3iWEYJttvB8cfRdHENgRtcES7HIJQAKC1RhzHiKJoYshhGGCtRd/3bjuK8b4ScRzPbEJYa2GtRdd1h7PJIQgVRRHiOEaSJEiSBFprZ0Aarus6GGNgrT2M8b4KURRBa40sy5CmqSOVUmoSYG3bomkaWGufnfLbcAhCKaWgtUaSJMiybEYorTWUUuj7fpYOfyOUUs4WaZoiSZKJavd9j67rnE2MMU/O+H04BKGAW8qj8RiRwI1QjExjzJ8hFANM2oRj77oOURRhGIbJ/iPgEISiAVkzcGOtAEyV6reD9mAZwLTHwGKw9X0/Cb6tWCr0X8VbCPXqjbHoJJEo8VprVzORcH+BUL4tZF0pCdV13UsKpZRy53xXbfoyoRhNwI1Mfd8/+cYcURQ5o3F2o7XGMAwz9eK1fjN8O8jZHm1irZ2o+R6QuMA4+Xm1wN93J/8Hb4jKYa11g/Z7I/xb9lUYIXmeu/NQmRiFSinEcYy+75EkCfI8n02V3xFZ/xV8e2itnT18UsnUJtWrKAo3E37Uk+K1mBFkbcZZozFmlygQuwkli0ZJKDqb9c/SACWZ0jR15+BAeQyAk3gSLU3TWQvBP//RCeanKI5X2kMGGMfuE4JES9MURVGgaRpnewBOzfxr0HfMCvRdkiSo6xpN06DrOuzBLkJxEHmeOzIAcIQyxswiRjqZg5MGI5G4yc9KAjKKGUVSon0VPDKWxiiVyB+ztIt/nJmC9gamtpDnj+MYWZY5dSKhhmGYzLCrqtpFqs2EoiSfTqdJ042FHfOw73BfNbhf67HwJnxS8fu8xiMFPLo6AXAOlPDVfc33ZLCyay5nxpJc9JFUKLYkaGtjzEQZy7Lc3OPaRKg4jpHnOc7ns2O5ZDgjJIoiR66llATAyeww3HopaZpODLRkuK7r0LYt2rZ1NZQfkT8NdKa0R5qmjhxLduB+krBtW6co9+xNonEGTZvLpmmSJOi6zimlUgrX63UTqVYTKo5jnE4nnM9nl+p4MwCcIlEm2c19Bg6AxbZPKBqC5+Pjht8C3/lsBeR57sbOjSpDMjFoq6pCXdd3rjBCdtWZ/mRhPgyD622RUEopfH5+ribVKkKRTB8fHyiKAnmez9RJSiqwTTH8NCYl3zfqvXTwm8DUJ1WK45Z2kA+H14J+kYRK03QiDFQoORFYS6qnhIrjGOfzGR8fHzidTiiKYlI7AWM9JIvrLZARxwHJYzTso/riN0GmM74ycP1je4KMxTwnV/5sjy0LWdArpXC5XJ6S6iGhJJnO5zOKonC1E4s51jZ8lTOQtZCk8Q30rAXxG+EHmBw/gJfJJAnFAl2mPb9lIX35jFR3CeWT6XQ6Ic9zZFnmLgiMvQ5r7UsKJSOPdRXwmvF+KmSAsaYC4MqKpZS4BbLVwG0p7fm+pJ8epb9FQsmaiWTyayeZ7sjqPepEkEx93zvDAXjJcD8VMrgYYLJO5T5+ZotdpELJFoIUCVk/0Ze8J0mqpUnXjFBaaxRF4VIciSRndrIYp7OlOm0llG9ADpj7ZfG5xXg/GRx3193WPTElAXBPCmiXrTZZIpXf5KQf+F76iNmiLMsZqSaE0vq2SpCKxJpJ1k2USGCcMVBVuG2FjDoSicbjIP7Kak1gao+2bScOlkH2LkJJYvn2l0TKsmyWbquqQt+Ps0xHKKWUe/jKlYJUJEkm2XtaUia5bYG1FsaYifGA24BeMd5PBMfcti2AsaaRhOr7W0OT6XAtaNd7KiWPAze/sOGZZZl7NcZMrs/61hHKz6dMbXzl5quQn+a2EgkY5R0Ym29LEfJXCMXx8mGvb3MGnayvtkISSoqAvI61duJ7WcSzkOcKBWKiUD5p5OZfXN7UK2QiKKFL6sYcvsdwPxUsuhlo0ia0w167+PZdyiw+yeh78uNeW2FSQ229MWLv9whpoIBpbfpdeGR7eYyp7d7nnb7J1MIqfmnj55aiIxDiZ+Ce37jf9/WjzS9DnELxIKejxhikaeqWNPC4TH3yhL7KBHIdH8MwfUJBReR+uXFiRG4YY9xCvEVCDcPtZ0p1Xc8Kc9m0BDCbcfgKFsh0XMjMIlWIYsGURnHhbI6rPJqmQV3XbmM7h5jUUJxZLM3qSCjewBKh+D7g2JB+o0JRnehXEsonUVVVqKoKZVm6dWkSs0553/eoqmpW+fNCvBk2wHgzvLGgUMeGr1CyTUO/cb9PprIsUZYlPj8/7y4RXnyW13UdyrK8Syj53Mfa8dGIVKqA44Jkot/4hIK+I8natp0Q6Xq94nK5PFxvfne1AUlFSFbL5Q4A3E9vAqmOD6lMfJW9rmEYXOEtlelyueDfv39P15k/XA9ljMH1enXv/dzLripvKqS940MKA4kji3HuZ6qjMq0hE7BixWbXdbherzMy+av8SCpZ4AUcEzLdkVBUKZKsaRpUVeXS3BoyASsIBUzTH4klf6TAvMstKNRxIVMea6dhGBdJklCcybFmWkMmYCWhgJFU/g1JlaJCUT4Djgfpv7ZtoZRyGcVa62qnqqoezubuYTWhgJFUMvWx6cliTtZRAceD9BOJovXtHyZhI5Oprq7rTWQCNhIKuBXgdV27G8uyzDU9ZR0VcFwwm7BVwAzD2qksy93/vsFmQgFjR51KRZWSaS8o1DEhZ3gy3cmZ3VIHfC12EQrApPj2G52BTMcFJ1Cy98T3TdO4nuJe7CYUMBZx1lr33I+1VSDVcSEzCXBTJ87uXi1XXiIUMCoSp57ymVDA8eCnPAoAJ1Ov4mVCAaOMyhUJgVTHBAnFv+m7d/lLAe/7z4P4bI94100GvA9KzX+I8E4/vZVQREh7x8VXB/2XECrg2PjKgA+ECngrtv9uPCDgAQKhAt6K/wF8T8blohi9BgAAAABJRU5ErkJggg=="/></g></mask><linearGradient id="New_Gradient_Swatch_copy-3" x1="71.55" y1="3.85" x2="71.55" y2="141.19" xlink:href="#New_Gradient_Swatch_copy"/><mask id="mask-3" x="29.59" y="102.52" width="84" height="43" maskUnits="userSpaceOnUse"><g class="cls-12"><image width="84" height="43" transform="translate(29.59 102.52)" xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFQAAAArCAYAAADmH6/VAAAACXBIWXMAAAsSAAALEgHS3X78AAAG5klEQVRoQ+2baXO6PBTFj8iivuj3/4ZFBS2ySALo88I58SaGqq1Ln5n/nckQkCX8PHdJbCcAjvhnD7Pg2gn/7D4L3QOTycRs3b6vBUFw8+e++7rPdfvf2fF4HO1zn33uHw4H69jxeLw4djgczLWy797TfS7gAHVBTKdTs2ULw9D05TlBECAMQ9OXTYKVgH2w5dbtA5cv4HtRAvJt3TYMA4ZhMH132/e9OYfH2XxQLaDH49G8IOFFUWRaGIbmGPts0+kUURRZ8H1fiAQ7pm7AD9WnyDG1+aBJUBJW3/emcb/rOnOMfa21OSafKe3C5eVJk8nEAIzj2GpRFCFJEgt2HMcXoMcgu+q+BnVsnD6QY/B8res6q2mtrX2llBkHv6DJZOKFCYwA5UDCMDQ3oALjOEaSJJjNZkiSxOz7ILvKluGC4WE6nXoVC4wDleocU6RU2zAMFiSCVEoZiFprKKUQRRGUUgiCU77m/YIgsNhIl5d2ARQ4DZSDIVSGA4Il3Pl8bgFmI2Aq2hcqpEK/U6pvfK46Xff2uawEqJRCkiRQSqFtWzMW9/2lOuUX5IMJjAAFTjfoug5BECCOY+smPrCz2cxqPOaGCjcO3+L6Ui3AOFDp3lKNEqDWGm3bmnHI+Eyv5HvzGO/JcMBx+GwUKAAMw2DkH4YhtNaI49hSbBAEVgylQufzuYErQ4MMAzK++lQKjGf5sbjpurdSyoxbKYX9fm+ecTwejYp9CiVIXqe1/hYmcAUocIJKlyA0rTVms5kVR6g0niNV68ZchgPp/o8A6iYapZR1f+CcWHie/Ezei6GhbVs0TYO2bTEMA67ZVaAA0Pc9mqaxEoqMlxIsw4F0bTcUUK1uoqLi3fjpc3lufbFTa219STxXui6fI+/D69u2NSDrukbTNOj7HrfYTUABoOs6lGVpYMmMz/rMBStVK68hWJ/b/yTLS4VKlfNzurR8BmAnGiqaSappGpRliaqqboYJ3AEUOEEtisICJSERLMsKAOYFpLrZ6PoyhgL3TT0JjQrncQnSp0aOkwmLcbKua1RVhd1uh7Is0XXdd0O4sLuAAoDWGkVRWFlelkcuWLc6cJUrlXOvuRWBC1dCdGOtVKQESZhFUUBrfWUEl3Y3UABo2xabzcbAoVJdsEwOBCszpAvjNzZ2HxkSJEQmGx/I7XaL7XYLpdTI0763HwEFzlB97i+zOauCJEkssG68fYRJJfoSFd27aRqTcKqqQlmW+Pr6wna7xWazQdu21x41aj8GCgD7/R5Zlpn458ZJt6gncFkzhmFoatqfmoRINbIIdxNNXddWnCyKwoDM8/xXMIFfAgVOUNfrtReoDAOyz885teW1PzWWRLKgp1vTtSXMsixRFIWlyizLsN/vrz3qqv0aKAA0TYPVamViqpt0uJXFvMzsVOdPoMr4KOfprirp2j6Qq9UKTdNce9RN9hCgAFDXNVar1QVQCdDN6lSnTCr3ZHtZjEtV+hS52+0skJvNBuv1+qEwgQcCBYCqqpCmqYEjVSj7ct8tbyTk74wwZbLZ7/cmc1OVRVFcqDLPc6xWKyyXS9R1/e1z7rWHAgVsqKwHJUjp5mMlk1voS5P1pEw8TdNYMJlwZNKRLv4MmMATgAJAWZbWvltzEpSv8D4cDojjeFTB0s2pTuniMnt/fX1ZyqSLp2mKqqrwDHsKUOAEVQJ0obIRplv6yOwvz5MzHbkaNAYzz3PkeY71eo3lcvlUmMATgQLAbrez9l33ljDl+mPf99YCtAuUSYhlkZvFOdvJssy4eJqmSNP0wnsebU8FCpyh+mKlq0oJlXWrVKgvEXF5zS2J8jxHlmVYr9dI0xSfn59Phwm8AChwqVSau2hBmPP53EwA5CqSrDlddbIsopsT5ufn58tgAi8CClxCdWMngTJzy1V9CVQW74ydPld/B0zghUCBM1QfzK7rrGTDBRYfUM6EXHXKgv2Vbi7tpUABW6nu8hqBLhYLy+0JlCFBa21WjNyVIpnNXw0TeANQ4ATVzfASKOfhBMq6ledJd5drmDKjvwMm8CagwLn4J1CZcFhfctkvCM5/tSGzO6eWzOpU57tgAm8ECpygyjgqFUq3dxVK2ATK2JllGZbL5VOL9lvsrUABGAAEyxjZti3m8zmiKLoAyjk7kxFd/Rlz83vt7UCBE1SpUkJbLBamuAfOQBk/i6IwieiRS3C/sT8BFDgvUrM0YuHOGArYQKuqMrHzESvtj7I/AxQ4/5zCTE6grkJZzG+321//BvRomwB/779AkiTBx8cHFosFkiTxKnS32/34p95n2p8ECgBRFJm/PSXQw+FgVubv/YuOV9mfBQpcrtzLVam/an8a6P/Rbv+J8Z/dZP8BNxxBu7/1eCsAAAAASUVORK5CYII="/></g></mask></defs><title>Asset 7@23x</title><g id="Layer_2" data-name="Layer 2"><g id="Layer_4" data-name="Layer 4"><path class="cls-2" d="M242.85,32.15,225.67,96.2H215.23L203.45,57.34,191.66,96.2H181.22L164.13,32.15h13.05l9.89,40.39,11.7-40.39h9.36l11.69,40.39,10-40.39Z"/><path class="cls-2" d="M283.16,72.72a42.29,42.29,0,0,1-1.08,10.71A16.85,16.85,0,0,1,277.85,91q-5.49,5.76-14.57,5.75T248.79,91a16.85,16.85,0,0,1-4.23-7.56,42.29,42.29,0,0,1-1.08-10.71q0-12.58,5.4-18.26t14.4-5.67q9.08,0,14.48,5.67T283.16,72.72Zm-11.79,0q0-8.64-2.67-11.33a7.27,7.27,0,0,0-5.42-2.07,7.16,7.16,0,0,0-5.34,2.07q-2.67,2.7-2.67,11.33t2.67,11.43a7.16,7.16,0,0,0,5.34,2.07,7.27,7.27,0,0,0,5.42-2.07Q271.37,81.45,271.37,72.72Z"/><path class="cls-2" d="M324.09,53.2l-8.81,8.91a8.6,8.6,0,0,0-6.21-2.79,7.16,7.16,0,0,0-5.13,2.07A8.87,8.87,0,0,0,301.51,68V96.2H289.82V49.33h11.42v4.5q4.23-5,11.79-5A15,15,0,0,1,324.09,53.2Z"/><path class="cls-2" d="M346.14,96.2h-6.66Q332.73,96.2,329,92a13.41,13.41,0,0,1-3.24-9.18V32.15h11.79V82.08q0,4.23,4.09,4.23h4.46Z"/><path class="cls-2" d="M388.42,96.2H377V91.8a14.83,14.83,0,0,1-11.61,4.94c-4.86,0-8.7-1.4-11.52-4.23q-3.15-3.14-4.14-9a68,68,0,0,1-.63-10.8,67.09,67.09,0,0,1,.63-10.7q1-5.85,4.13-9,4.22-4.23,11.39-4.23t11.39,4.68V32.15h11.78ZM376.64,72.72c0-4.44-.45-7.61-1.34-9.53q-1.79-3.87-6.58-3.87c-3.38,0-5.67,1.5-6.85,4.5q-1,2.68-1,8.9t1,8.91a6.72,6.72,0,0,0,6.85,4.59q4.8,0,6.58-3.87Q376.64,79.38,376.64,72.72Z"/><path class="cls-2" d="M443.12,69.69q0,13.44-5.94,19.66a23.77,23.77,0,0,1-17.9,7.39,23.48,23.48,0,0,1-17.27-7,20.54,20.54,0,0,1-5.58-11.07q-.72-4-.72-14.49t.72-14.48A20.54,20.54,0,0,1,402,38.62a23.48,23.48,0,0,1,17.27-7,28.36,28.36,0,0,1,11,1.89,29.93,29.93,0,0,1,8.63,6.29l-8.45,8.46a25.54,25.54,0,0,0-5-4.14,13.15,13.15,0,0,0-6.12-1.35,10.24,10.24,0,0,0-8,3.42q-2.34,2.7-2.88,8.64-.18,1.62-.18,9.35t.18,9.36q.54,6,2.88,8.73a10.2,10.2,0,0,0,8,3.33,11.12,11.12,0,0,0,8.55-3.6c1.85-2,2.79-4.95,2.79-8.73V71H419.28V60.49h23.84Z"/><path class="cls-2" d="M487.47,72.72a42.29,42.29,0,0,1-1.08,10.71A16.83,16.83,0,0,1,482.17,91q-5.49,5.76-14.58,5.75T453.11,91a16.85,16.85,0,0,1-4.23-7.56,42.29,42.29,0,0,1-1.08-10.71q0-12.58,5.4-18.26t14.39-5.67q9.09,0,14.49,5.67T487.47,72.72Zm-11.78,0q0-8.64-2.67-11.33a7.3,7.3,0,0,0-5.43-2.07,7.2,7.2,0,0,0-5.34,2.07q-2.67,2.7-2.67,11.33t2.67,11.43a7.2,7.2,0,0,0,5.34,2.07A7.3,7.3,0,0,0,473,84.15Q475.69,81.45,475.69,72.72Z"/><path class="cls-2" d="M532.64,96.2H521.21V91.89a15.41,15.41,0,0,1-11.69,4.85q-6.93,0-11.07-4.14-4.77-4.75-4.77-13.31v-30h11.79V77.67q0,4.41,2.49,6.66a7.3,7.3,0,0,0,5.16,1.89,7.41,7.41,0,0,0,5.24-1.89q2.49-2.25,2.49-6.66V49.33h11.79Z"/><path class="cls-2" d="M575.46,53.2l-8.81,8.91a8.6,8.6,0,0,0-6.21-2.79,7.16,7.16,0,0,0-5.13,2.07A8.87,8.87,0,0,0,552.88,68V96.2h-11.7V49.33h11.43v4.5q4.23-5,11.79-5A15,15,0,0,1,575.46,53.2Z"/><path class="cls-2" d="M615.05,96.2H603.62V91.8A14.82,14.82,0,0,1,592,96.74c-4.86,0-8.7-1.4-11.52-4.23q-3.15-3.14-4.14-9a68,68,0,0,1-.63-10.8,67.09,67.09,0,0,1,.63-10.7q1-5.85,4.13-9,4.2-4.23,11.38-4.23t11.39,4.68V32.15h11.79ZM603.26,72.72c0-4.44-.44-7.61-1.33-9.53q-1.78-3.87-6.58-3.87c-3.38,0-5.67,1.5-6.85,4.5-.66,1.79-1,4.76-1,8.9s.32,7.11,1,8.91a6.72,6.72,0,0,0,6.85,4.59q4.8,0,6.58-3.87Q603.27,79.38,603.26,72.72Z"/><g class="cls-3"><rect class="cls-1" x="56.06" y="65.16" width="45.17" height="3.01"/><path class="cls-4" d="M74.94,1.4a4.79,4.79,0,0,0-6.77,0L32.52,37.06h78.07Z"/><g class="cls-5"><g class="cls-6"><path d="M74.94,1.4a4.79,4.79,0,0,0-6.77,0L32.52,37.06h78.07Z"/></g></g><path class="cls-7" d="M141.71,68.17,125.32,51.78v4.34h-14v-8h-12v8H42v-8H31v8H16.91V52.66L1.4,68.17a4.79,4.79,0,0,0,0,6.77L19.92,93.46V60.14H31v11H42v-11H99.22v11h12v-11h11v34.2l19.4-19.4A4.79,4.79,0,0,0,141.71,68.17Z"/><g class="cls-8"><g class="cls-6"><path d="M141.71,68.17,125.32,51.78v4.34h-14v-8h-12v8H42v-8H31v8H16.91V52.66L1.4,68.17a4.79,4.79,0,0,0,0,6.77L19.92,93.46V60.14H31v11H42v-11H99.22v11h12v-11h11v34.2l19.4-19.4A4.79,4.79,0,0,0,141.71,68.17Z"/></g></g><path class="cls-9" d="M68.17,141.71a4.77,4.77,0,0,0,6.76,0l36.41-36.4H31.77Z"/><g class="cls-10"><g class="cls-6"><path d="M68.17,141.71a4.77,4.77,0,0,0,6.76,0l36.41-36.4H31.77Z"/></g></g><polygon class="cls-11" points="111.27 60.14 111.27 71.18 99.22 71.18 99.22 60.14 42.01 60.14 42.01 71.18 30.96 71.18 30.96 60.14 19.92 60.14 19.92 93.46 31.77 105.31 111.33 105.31 122.31 94.34 122.31 60.14 111.27 60.14"/><polygon class="cls-11" points="23.71 56.13 30.96 56.13 30.97 48.1 42.01 48.1 42.01 56.13 99.22 56.12 99.22 48.09 111.27 48.09 111.27 56.12 119.07 56.12 125.32 56.12 125.32 51.78 110.59 37.05 32.52 37.05 16.91 52.66 16.91 56.13 23.71 56.13"/><rect class="cls-11" x="49.03" y="61.14" width="5.02" height="14.05"/></g></g></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="worldgourd-logo.svg"
+   id="svg1019"
+   version="1.1"
+   viewBox="0 0 615.05 143.11">
+  <metadata
+     id="metadata1023">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:current-layer="Layer_4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="1912"
+     inkscape:cy="-39.108423"
+     inkscape:cx="246.12506"
+     inkscape:zoom="0.98528575"
+     showgrid="false"
+     id="namedview1021"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <defs
+     id="defs959">
+    <style
+       id="style929">.cls-1{fill:none;}.cls-2{fill:#2d2d2d;}.cls-3{clip-path:url(#clip-path);}.cls-4{fill:url(#New_Gradient_Swatch_copy);}.cls-5{mask:url(#mask);}.cls-6{opacity:0.1;}.cls-7{fill:url(#New_Gradient_Swatch_copy-2);}.cls-8{mask:url(#mask-2);}.cls-9{fill:url(#New_Gradient_Swatch_copy-3);}.cls-10{mask:url(#mask-3);}.cls-11{fill:#fff;}.cls-12{filter:url(#luminosity-invert);}</style>
+    <clipPath
+       id="clip-path">
+      <path
+         id="path931"
+         d="M78.54,138.1c-3.85,3.85-10.45,3.45-14.33-.42L5.07,78.54a9.85,9.85,0,0,1-.07-14L63.63,6c3.85-3.85,11.25-4.68,15.13-.8l59,59c3.88,3.88,3.63,11.13-.23,15Z"
+         class="cls-1" />
+    </clipPath>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="141.19"
+       x2="71.56"
+       y1="3.86"
+       x1="71.56"
+       id="New_Gradient_Swatch_copy">
+      <stop
+         id="stop934"
+         stop-color="#006bff"
+         offset="0" />
+      <stop
+         id="stop936"
+         stop-color="#004dff"
+         offset="1" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       filterUnits="userSpaceOnUse"
+       id="luminosity-invert">
+      <feColorMatrix
+         id="feColorMatrix939"
+         values="-1 0 0 0 1 0 -1 0 0 1 0 0 -1 0 1 0 0 0 1 0" />
+    </filter>
+    <mask
+       maskUnits="userSpaceOnUse"
+       height="42"
+       width="83"
+       y="-2.48"
+       x="29.59"
+       id="mask">
+      <g
+         id="g944"
+         class="cls-12">
+        <image
+           id="image942"
+           xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFMAAAAqCAYAAADPn2cJAAAACXBIWXMAAAsSAAALEgHS3X78AAAGoklEQVRoQ+2bWXObQBCEGxDLcsjR6eT//7vEcbmcyDE3eVD11jBaST50PXiqKKILlo+entnFCQAM+IqTRHjsC1/x9pgc+8I1IwxDRFEEAAiCAH3fu+0W42ZhTiYTWGthjHFA27ZF0zQoyxJt2x45wuXjJmHGcYyiKJDn+Qhm13Wo6xovLy/YbDZomubIkS4bNwczSRJ8+/ZtBDMMt9be9z3qukaSJDDG4Pn5GWVZHjni5eKmYFprMZ/PcXd3h+l0iizLEMfxSJlN0yBJEsRxjDAM8fT0dDNAbwamtRar1Qrz+RzT6RRFUcBaiyRJRsqsqsq9T9CPj494fX09cobzx03ATNMUq9UKy+USs9kM0+kUeZ7DWutVZlmWDuZkMkEYhnh4eLg60KvDzLIM6/Uay+USi8Vi5JcynYGtMpum2VFnGIYO6MvLy5Ezni+uCjPLMtzf32O9XmOxWGA2m+Hu7g5FUSDLsqMwqcwoihBFEYIgwK9fv64G9Gow8zzH9+/fsVqtnFfOZjMURYGiKJCm6VGYxhgkSeKABkHggG42myMjOH1cBSZB3t/fY7lcOq+UKU6Y9ERgC7NtW5Rl6dKcfShhhmGIIAgwDMPFFXpxmHme48ePH1iv1zteOZ1OXUskZz+yALVtizRNXREyxjhl0juB7fTz58+f+Pv376HhnDQuCpMg6ZMEOZ/PnSqZ4tITtTLZa/pAMtX5m2EYLpbyF4MpQcr0plfKwpOmKYwxDlYQBAC2YNq2Hc2C4jh27ROhEugwbFcXL6XQi8DUINlTEiRTPM/zUYpLSMA2zdlr1nU9quZSmQB29pdQ6Nlh7gMp05sznizLXEtEmNIHufwmYUpF+mACuJhCzwpTVm16pATJ2Q5hsoLLmQ+rNLCF0nXdTmrr9GYMw+A2vu77/mxV/mwwsyxzINlLMrUlSO2VcprI4iNhsggRIj1Vf88XUqHnSPmzwCTI9Xq9k9bSIyVImd5siWSKM/q+dxClGiVIqUTeAG7y9b9//3bG/pk4OUw5RZQgZ7PZCKT2SRYdVnCpNBm+NkiDPASRewAnn3qeFGaapg6iVCIhUolylsOeUk4NtRp1BEHgKjxjH8S2bV0X0HXd6BkSv3uq1aaTwbTW7i0yhJjnuYNorXUeqRX51pBAj0H0Ae26DsMw4OHh4SQpfxKYXNhdLBYupaUS8zzfUaNuut8LkhGG2yeYcRyPWqc0TdG2rZsxyb0EK2/CZ1fsPw3TWrvTN/Kxg0xpLkxob5RN90eClVxWd2MM2raFtXYEVkLVYIdhwO/fvz8F9FMwkyQZtToSopzNSIi67ZF95EdDzsfDMHTHj+PYeXFd10jT1DX8hEmgVOfj4yOqqjp2Sm98GKYxZm9hkRCPLUicImRf6QNLK+F4rLXIsswpVKq073s8PT19COiHYMZx7CBKkNIPZfMtZyq6jem6zr2/rx06FLLosPUhXAmWFqChUq3SBgj0vc/l3w0zjmPXJ3JxgtWZ00C9AEFAsopybZKf6dXyQ1D19JBFR6YtVeYDK9VqrUVVVQ6qLE5//vx5F9B3wZxMJsjz/CBELk7oKSDhUQEsOPJzpqZWqJ4mcs/CIW+O9kQJlsciVN50+qq11v2Wv9tsNm/+U5w3w4yiCFmWjSD65tEMDZEApUrbtt2xAl4o4F9G41436F3XOYAEUpYlqqryFhuGzwKste77fb+ddr4F6JtgRlHkTFtDlKnpA1hVlVeF2g58xWlfuyS9UcKUyqdCq6oabbLg8Di+gmWMgbXWwX99fUXXdd7xMI7CZDr4WhupGF5IXdcjlTINeZGEKCu8hikVrL1TqpLH3geUCvVBresadV2PFMjzyX61abaPSLpu+0djh4AehEmQvqeAvKtahTqNm6aBMQZVVY18VTfsPK5UOuCHyb2u5NI7pUK5EWJVVc4C+J60AILluIwxo4ImbULGXpi8MAlQp7IuJBosZzoaYByPV8hl1ZcprkEyOAad6hKo9FCtVKlWKlT6qwTHsVCt8rw6vDClh2hYhwAyfSU8mc4yrWkFMq0lUI7DFzrVJVyCkJXcp9Z9gOVGsARHqLxxGuhemNIPOTipTJ6cSpOK0/B8RUaD9MHkWGTINJfj03uqVO4JWO6leiVwvecxfHwYOzA1RN4ZqtIHR9rBIWhvUeIhkAx5AT6VcuPYtbdqwNoe+Fqrm+/viwDY/a8rvouTfqY3Hxyf2uSmzyP3vrEwfF7lU6v+t7YD32v9md58x5bhhfkVH4uPLSJ+hTf+A45XAcRn3tf4AAAAAElFTkSuQmCC"
+           transform="translate(29.59 -2.48)"
+           height="42"
+           width="83" />
+      </g>
+    </mask>
+    <linearGradient
+       xlink:href="#New_Gradient_Swatch_copy"
+       y2="141.19"
+       x2="71.55"
+       y1="3.86"
+       x1="71.55"
+       id="New_Gradient_Swatch_copy-2" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       height="51"
+       width="148"
+       y="45.52"
+       x="-2.41"
+       id="mask-2">
+      <g
+         id="g950"
+         class="cls-12">
+        <image
+           id="image948"
+           xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJQAAAAzCAYAAABxJSGCAAAACXBIWXMAAAsSAAALEgHS3X78AAAInklEQVR4Xu1d63arvA4cY65J3/9BdxpuBnN+5IwRhiRA0n609azFSgMJYGk0koWztwIwICDgTYiefSAgYAviZx/4Diil3Cs3iWEYJttvB8cfRdHENgRtcES7HIJQAKC1RhzHiKJoYshhGGCtRd/3bjuK8b4ScRzPbEJYa2GtRdd1h7PJIQgVRRHiOEaSJEiSBFprZ0Aarus6GGNgrT2M8b4KURRBa40sy5CmqSOVUmoSYG3bomkaWGufnfLbcAhCKaWgtUaSJMiybEYorTWUUuj7fpYOfyOUUs4WaZoiSZKJavd9j67rnE2MMU/O+H04BKGAW8qj8RiRwI1QjExjzJ8hFANM2oRj77oOURRhGIbJ/iPgEISiAVkzcGOtAEyV6reD9mAZwLTHwGKw9X0/Cb6tWCr0X8VbCPXqjbHoJJEo8VprVzORcH+BUL4tZF0pCdV13UsKpZRy53xXbfoyoRhNwI1Mfd8/+cYcURQ5o3F2o7XGMAwz9eK1fjN8O8jZHm1irZ2o+R6QuMA4+Xm1wN93J/8Hb4jKYa11g/Z7I/xb9lUYIXmeu/NQmRiFSinEcYy+75EkCfI8n02V3xFZ/xV8e2itnT18UsnUJtWrKAo3E37Uk+K1mBFkbcZZozFmlygQuwkli0ZJKDqb9c/SACWZ0jR15+BAeQyAk3gSLU3TWQvBP//RCeanKI5X2kMGGMfuE4JES9MURVGgaRpnewBOzfxr0HfMCvRdkiSo6xpN06DrOuzBLkJxEHmeOzIAcIQyxswiRjqZg5MGI5G4yc9KAjKKGUVSon0VPDKWxiiVyB+ztIt/nJmC9gamtpDnj+MYWZY5dSKhhmGYzLCrqtpFqs2EoiSfTqdJ042FHfOw73BfNbhf67HwJnxS8fu8xiMFPLo6AXAOlPDVfc33ZLCyay5nxpJc9JFUKLYkaGtjzEQZy7Lc3OPaRKg4jpHnOc7ns2O5ZDgjJIoiR66llATAyeww3HopaZpODLRkuK7r0LYt2rZ1NZQfkT8NdKa0R5qmjhxLduB+krBtW6co9+xNonEGTZvLpmmSJOi6zimlUgrX63UTqVYTKo5jnE4nnM9nl+p4MwCcIlEm2c19Bg6AxbZPKBqC5+Pjht8C3/lsBeR57sbOjSpDMjFoq6pCXdd3rjBCdtWZ/mRhPgyD622RUEopfH5+ribVKkKRTB8fHyiKAnmez9RJSiqwTTH8NCYl3zfqvXTwm8DUJ1WK45Z2kA+H14J+kYRK03QiDFQoORFYS6qnhIrjGOfzGR8fHzidTiiKYlI7AWM9JIvrLZARxwHJYzTso/riN0GmM74ycP1je4KMxTwnV/5sjy0LWdArpXC5XJ6S6iGhJJnO5zOKonC1E4s51jZ8lTOQtZCk8Q30rAXxG+EHmBw/gJfJJAnFAl2mPb9lIX35jFR3CeWT6XQ6Ic9zZFnmLgiMvQ5r7UsKJSOPdRXwmvF+KmSAsaYC4MqKpZS4BbLVwG0p7fm+pJ8epb9FQsmaiWTyayeZ7sjqPepEkEx93zvDAXjJcD8VMrgYYLJO5T5+ZotdpELJFoIUCVk/0Ze8J0mqpUnXjFBaaxRF4VIciSRndrIYp7OlOm0llG9ADpj7ZfG5xXg/GRx3193WPTElAXBPCmiXrTZZIpXf5KQf+F76iNmiLMsZqSaE0vq2SpCKxJpJ1k2USGCcMVBVuG2FjDoSicbjIP7Kak1gao+2bScOlkH2LkJJYvn2l0TKsmyWbquqQt+Ps0xHKKWUe/jKlYJUJEkm2XtaUia5bYG1FsaYifGA24BeMd5PBMfcti2AsaaRhOr7W0OT6XAtaNd7KiWPAze/sOGZZZl7NcZMrs/61hHKz6dMbXzl5quQn+a2EgkY5R0Ym29LEfJXCMXx8mGvb3MGnayvtkISSoqAvI61duJ7WcSzkOcKBWKiUD5p5OZfXN7UK2QiKKFL6sYcvsdwPxUsuhlo0ia0w167+PZdyiw+yeh78uNeW2FSQ229MWLv9whpoIBpbfpdeGR7eYyp7d7nnb7J1MIqfmnj55aiIxDiZ+Ce37jf9/WjzS9DnELxIKejxhikaeqWNPC4TH3yhL7KBHIdH8MwfUJBReR+uXFiRG4YY9xCvEVCDcPtZ0p1Xc8Kc9m0BDCbcfgKFsh0XMjMIlWIYsGURnHhbI6rPJqmQV3XbmM7h5jUUJxZLM3qSCjewBKh+D7g2JB+o0JRnehXEsonUVVVqKoKZVm6dWkSs0553/eoqmpW+fNCvBk2wHgzvLGgUMeGr1CyTUO/cb9PprIsUZYlPj8/7y4RXnyW13UdyrK8Syj53Mfa8dGIVKqA44Jkot/4hIK+I8natp0Q6Xq94nK5PFxvfne1AUlFSFbL5Q4A3E9vAqmOD6lMfJW9rmEYXOEtlelyueDfv39P15k/XA9ljMH1enXv/dzLripvKqS940MKA4kji3HuZ6qjMq0hE7BixWbXdbherzMy+av8SCpZ4AUcEzLdkVBUKZKsaRpUVeXS3BoyASsIBUzTH4klf6TAvMstKNRxIVMea6dhGBdJklCcybFmWkMmYCWhgJFU/g1JlaJCUT4Djgfpv7ZtoZRyGcVa62qnqqoezubuYTWhgJFUMvWx6cliTtZRAceD9BOJovXtHyZhI5Oprq7rTWQCNhIKuBXgdV27G8uyzDU9ZR0VcFwwm7BVwAzD2qksy93/vsFmQgFjR51KRZWSaS8o1DEhZ3gy3cmZ3VIHfC12EQrApPj2G52BTMcFJ1Cy98T3TdO4nuJe7CYUMBZx1lr33I+1VSDVcSEzCXBTJ87uXi1XXiIUMCoSp57ymVDA8eCnPAoAJ1Ov4mVCAaOMyhUJgVTHBAnFv+m7d/lLAe/7z4P4bI94100GvA9KzX+I8E4/vZVQREh7x8VXB/2XECrg2PjKgA+ECngrtv9uPCDgAQKhAt6K/wF8T8blohi9BgAAAABJRU5ErkJggg=="
+           transform="translate(-2.41 45.52)"
+           height="51"
+           width="148" />
+      </g>
+    </mask>
+    <linearGradient
+       xlink:href="#New_Gradient_Swatch_copy"
+       y2="141.19"
+       x2="71.55"
+       y1="3.85"
+       x1="71.55"
+       id="New_Gradient_Swatch_copy-3" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       height="43"
+       width="84"
+       y="102.52"
+       x="29.59"
+       id="mask-3">
+      <g
+         id="g956"
+         class="cls-12">
+        <image
+           id="image954"
+           xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFQAAAArCAYAAADmH6/VAAAACXBIWXMAAAsSAAALEgHS3X78AAAG5klEQVRoQ+2baXO6PBTFj8iivuj3/4ZFBS2ySALo88I58SaGqq1Ln5n/nckQkCX8PHdJbCcAjvhnD7Pg2gn/7D4L3QOTycRs3b6vBUFw8+e++7rPdfvf2fF4HO1zn33uHw4H69jxeLw4djgczLWy797TfS7gAHVBTKdTs2ULw9D05TlBECAMQ9OXTYKVgH2w5dbtA5cv4HtRAvJt3TYMA4ZhMH132/e9OYfH2XxQLaDH49G8IOFFUWRaGIbmGPts0+kUURRZ8H1fiAQ7pm7AD9WnyDG1+aBJUBJW3/emcb/rOnOMfa21OSafKe3C5eVJk8nEAIzj2GpRFCFJEgt2HMcXoMcgu+q+BnVsnD6QY/B8res6q2mtrX2llBkHv6DJZOKFCYwA5UDCMDQ3oALjOEaSJJjNZkiSxOz7ILvKluGC4WE6nXoVC4wDleocU6RU2zAMFiSCVEoZiFprKKUQRRGUUgiCU77m/YIgsNhIl5d2ARQ4DZSDIVSGA4Il3Pl8bgFmI2Aq2hcqpEK/U6pvfK46Xff2uawEqJRCkiRQSqFtWzMW9/2lOuUX5IMJjAAFTjfoug5BECCOY+smPrCz2cxqPOaGCjcO3+L6Ui3AOFDp3lKNEqDWGm3bmnHI+Eyv5HvzGO/JcMBx+GwUKAAMw2DkH4YhtNaI49hSbBAEVgylQufzuYErQ4MMAzK++lQKjGf5sbjpurdSyoxbKYX9fm+ecTwejYp9CiVIXqe1/hYmcAUocIJKlyA0rTVms5kVR6g0niNV68ZchgPp/o8A6iYapZR1f+CcWHie/Ezei6GhbVs0TYO2bTEMA67ZVaAA0Pc9mqaxEoqMlxIsw4F0bTcUUK1uoqLi3fjpc3lufbFTa219STxXui6fI+/D69u2NSDrukbTNOj7HrfYTUABoOs6lGVpYMmMz/rMBStVK68hWJ/b/yTLS4VKlfNzurR8BmAnGiqaSappGpRliaqqboYJ3AEUOEEtisICJSERLMsKAOYFpLrZ6PoyhgL3TT0JjQrncQnSp0aOkwmLcbKua1RVhd1uh7Is0XXdd0O4sLuAAoDWGkVRWFlelkcuWLc6cJUrlXOvuRWBC1dCdGOtVKQESZhFUUBrfWUEl3Y3UABo2xabzcbAoVJdsEwOBCszpAvjNzZ2HxkSJEQmGx/I7XaL7XYLpdTI0763HwEFzlB97i+zOauCJEkssG68fYRJJfoSFd27aRqTcKqqQlmW+Pr6wna7xWazQdu21x41aj8GCgD7/R5Zlpn458ZJt6gncFkzhmFoatqfmoRINbIIdxNNXddWnCyKwoDM8/xXMIFfAgVOUNfrtReoDAOyz885teW1PzWWRLKgp1vTtSXMsixRFIWlyizLsN/vrz3qqv0aKAA0TYPVamViqpt0uJXFvMzsVOdPoMr4KOfprirp2j6Qq9UKTdNce9RN9hCgAFDXNVar1QVQCdDN6lSnTCr3ZHtZjEtV+hS52+0skJvNBuv1+qEwgQcCBYCqqpCmqYEjVSj7ct8tbyTk74wwZbLZ7/cmc1OVRVFcqDLPc6xWKyyXS9R1/e1z7rWHAgVsqKwHJUjp5mMlk1voS5P1pEw8TdNYMJlwZNKRLv4MmMATgAJAWZbWvltzEpSv8D4cDojjeFTB0s2pTuniMnt/fX1ZyqSLp2mKqqrwDHsKUOAEVQJ0obIRplv6yOwvz5MzHbkaNAYzz3PkeY71eo3lcvlUmMATgQLAbrez9l33ljDl+mPf99YCtAuUSYhlkZvFOdvJssy4eJqmSNP0wnsebU8FCpyh+mKlq0oJlXWrVKgvEXF5zS2J8jxHlmVYr9dI0xSfn59Phwm8AChwqVSau2hBmPP53EwA5CqSrDlddbIsopsT5ufn58tgAi8CClxCdWMngTJzy1V9CVQW74ydPld/B0zghUCBM1QfzK7rrGTDBRYfUM6EXHXKgv2Vbi7tpUABW6nu8hqBLhYLy+0JlCFBa21WjNyVIpnNXw0TeANQ4ATVzfASKOfhBMq6ledJd5drmDKjvwMm8CagwLn4J1CZcFhfctkvCM5/tSGzO6eWzOpU57tgAm8ECpygyjgqFUq3dxVK2ATK2JllGZbL5VOL9lvsrUABGAAEyxjZti3m8zmiKLoAyjk7kxFd/Rlz83vt7UCBE1SpUkJbLBamuAfOQBk/i6IwieiRS3C/sT8BFDgvUrM0YuHOGArYQKuqMrHzESvtj7I/AxQ4/5zCTE6grkJZzG+321//BvRomwB/779AkiTBx8cHFosFkiTxKnS32/34p95n2p8ECgBRFJm/PSXQw+FgVubv/YuOV9mfBQpcrtzLVam/an8a6P/Rbv+J8Z/dZP8BNxxBu7/1eCsAAAAASUVORK5CYII="
+           transform="translate(29.59 102.52)"
+           height="43"
+           width="84" />
+      </g>
+    </mask>
+  </defs>
+  <title
+     id="title961">Asset 7@23x</title>
+  <g
+     data-name="Layer 2"
+     id="Layer_2">
+    <g
+       data-name="Layer 4"
+       id="Layer_4">
+      <path
+         id="path963"
+         d="M242.85,32.15,225.67,96.2H215.23L203.45,57.34,191.66,96.2H181.22L164.13,32.15h13.05l9.89,40.39,11.7-40.39h9.36l11.69,40.39,10-40.39Z"
+         class="cls-2" />
+      <path
+         id="path965"
+         d="M283.16,72.72a42.29,42.29,0,0,1-1.08,10.71A16.85,16.85,0,0,1,277.85,91q-5.49,5.76-14.57,5.75T248.79,91a16.85,16.85,0,0,1-4.23-7.56,42.29,42.29,0,0,1-1.08-10.71q0-12.58,5.4-18.26t14.4-5.67q9.08,0,14.48,5.67T283.16,72.72Zm-11.79,0q0-8.64-2.67-11.33a7.27,7.27,0,0,0-5.42-2.07,7.16,7.16,0,0,0-5.34,2.07q-2.67,2.7-2.67,11.33t2.67,11.43a7.16,7.16,0,0,0,5.34,2.07,7.27,7.27,0,0,0,5.42-2.07Q271.37,81.45,271.37,72.72Z"
+         class="cls-2" />
+      <path
+         id="path967"
+         d="M324.09,53.2l-8.81,8.91a8.6,8.6,0,0,0-6.21-2.79,7.16,7.16,0,0,0-5.13,2.07A8.87,8.87,0,0,0,301.51,68V96.2H289.82V49.33h11.42v4.5q4.23-5,11.79-5A15,15,0,0,1,324.09,53.2Z"
+         class="cls-2" />
+      <path
+         id="path969"
+         d="M346.14,96.2h-6.66Q332.73,96.2,329,92a13.41,13.41,0,0,1-3.24-9.18V32.15h11.79V82.08q0,4.23,4.09,4.23h4.46Z"
+         class="cls-2" />
+      <path
+         id="path971"
+         d="M388.42,96.2H377V91.8a14.83,14.83,0,0,1-11.61,4.94c-4.86,0-8.7-1.4-11.52-4.23q-3.15-3.14-4.14-9a68,68,0,0,1-.63-10.8,67.09,67.09,0,0,1,.63-10.7q1-5.85,4.13-9,4.22-4.23,11.39-4.23t11.39,4.68V32.15h11.78ZM376.64,72.72c0-4.44-.45-7.61-1.34-9.53q-1.79-3.87-6.58-3.87c-3.38,0-5.67,1.5-6.85,4.5q-1,2.68-1,8.9t1,8.91a6.72,6.72,0,0,0,6.85,4.59q4.8,0,6.58-3.87Q376.64,79.38,376.64,72.72Z"
+         class="cls-2" />
+      <path
+         id="path973"
+         d="M443.12,69.69q0,13.44-5.94,19.66a23.77,23.77,0,0,1-17.9,7.39,23.48,23.48,0,0,1-17.27-7,20.54,20.54,0,0,1-5.58-11.07q-.72-4-.72-14.49t.72-14.48A20.54,20.54,0,0,1,402,38.62a23.48,23.48,0,0,1,17.27-7,28.36,28.36,0,0,1,11,1.89,29.93,29.93,0,0,1,8.63,6.29l-8.45,8.46a25.54,25.54,0,0,0-5-4.14,13.15,13.15,0,0,0-6.12-1.35,10.24,10.24,0,0,0-8,3.42q-2.34,2.7-2.88,8.64-.18,1.62-.18,9.35t.18,9.36q.54,6,2.88,8.73a10.2,10.2,0,0,0,8,3.33,11.12,11.12,0,0,0,8.55-3.6c1.85-2,2.79-4.95,2.79-8.73V71H419.28V60.49h23.84Z"
+         class="cls-2" />
+      <path
+         id="path975"
+         d="M487.47,72.72a42.29,42.29,0,0,1-1.08,10.71A16.83,16.83,0,0,1,482.17,91q-5.49,5.76-14.58,5.75T453.11,91a16.85,16.85,0,0,1-4.23-7.56,42.29,42.29,0,0,1-1.08-10.71q0-12.58,5.4-18.26t14.39-5.67q9.09,0,14.49,5.67T487.47,72.72Zm-11.78,0q0-8.64-2.67-11.33a7.3,7.3,0,0,0-5.43-2.07,7.2,7.2,0,0,0-5.34,2.07q-2.67,2.7-2.67,11.33t2.67,11.43a7.2,7.2,0,0,0,5.34,2.07A7.3,7.3,0,0,0,473,84.15Q475.69,81.45,475.69,72.72Z"
+         class="cls-2" />
+      <path
+         id="path977"
+         d="M532.64,96.2H521.21V91.89a15.41,15.41,0,0,1-11.69,4.85q-6.93,0-11.07-4.14-4.77-4.75-4.77-13.31v-30h11.79V77.67q0,4.41,2.49,6.66a7.3,7.3,0,0,0,5.16,1.89,7.41,7.41,0,0,0,5.24-1.89q2.49-2.25,2.49-6.66V49.33h11.79Z"
+         class="cls-2" />
+      <path
+         id="path979"
+         d="M575.46,53.2l-8.81,8.91a8.6,8.6,0,0,0-6.21-2.79,7.16,7.16,0,0,0-5.13,2.07A8.87,8.87,0,0,0,552.88,68V96.2h-11.7V49.33h11.43v4.5q4.23-5,11.79-5A15,15,0,0,1,575.46,53.2Z"
+         class="cls-2" />
+      <path
+         id="path981"
+         d="M615.05,96.2H603.62V91.8A14.82,14.82,0,0,1,592,96.74c-4.86,0-8.7-1.4-11.52-4.23q-3.15-3.14-4.14-9a68,68,0,0,1-.63-10.8,67.09,67.09,0,0,1,.63-10.7q1-5.85,4.13-9,4.2-4.23,11.38-4.23t11.39,4.68V32.15h11.79ZM603.26,72.72c0-4.44-.44-7.61-1.33-9.53q-1.78-3.87-6.58-3.87c-3.38,0-5.67,1.5-6.85,4.5-.66,1.79-1,4.76-1,8.9s.32,7.11,1,8.91a6.72,6.72,0,0,0,6.85,4.59q4.8,0,6.58-3.87Q603.27,79.38,603.26,72.72Z"
+         class="cls-2" />
+      <g
+         id="g1082">
+        <rect
+           style="fill:#cc8118;fill-opacity:1;stroke-width:2.19897;stroke-miterlimit:4;stroke-dasharray:none"
+           id="rect1033"
+           width="105.22397"
+           height="105.22397"
+           x="53.828701"
+           y="-58.471001"
+           ry="12.716467"
+           rx="12.716467"
+           transform="rotate(45)" />
+        <g
+           id="g1075"
+           transform="translate(-1.6147501,-3.7677503)">
+          <path
+             id="path1070"
+             d="m 76.790338,56.69567 c 0.158053,-1.612077 0.512014,-3.303972 0.897083,-4.84425 0.244202,-0.976807 0,-2.392633 0,-3.408917 0,-0.53825 0,-1.0765 0,-1.61475 0,-0.119611 0.119611,-0.358834 0,-0.358834 -0.0598,0 -0.0598,0.179417 0,0.179417 0.08458,0 0.141593,-0.103768 0.179417,-0.179417 0.174464,-0.348927 0.208451,-0.596318 0.358833,-0.897083 0.07537,-0.150731 0.08079,-0.798456 0.179417,-0.897083 0.04229,-0.04229 0.137128,0.04229 0.179417,0 0.06927,-0.06927 0.483458,-1.27096 0.53825,-1.435334 0.175617,-0.526851 0.07112,-0.250541 0.358833,-0.53825 0.340506,-0.340506 0.26809,-1.388927 0.53825,-1.794167 0.140746,-0.211119 0.424777,-0.311303 0.53825,-0.53825 0.05349,-0.106983 -0.08458,-0.274255 0,-0.358833 0.169613,-0.169613 0.567572,-0.388155 0.717667,-0.53825 0.36119,-0.36119 0.700629,-1.157689 1.255917,-1.435333 0.733467,-0.366734 1.542942,0.65306 2.153,0.897083 0.58753,0.235012 3.567495,0.496574 3.76775,0.897083 0.0418,0.08359 -2.297512,2.227703 -2.69125,3.408917 -0.01891,0.05674 0,0.119611 0,0.179417 -0.119611,0.05981 -0.284654,0.06815 -0.358834,0.179417 -0.06635,0.09952 0.02901,0.242793 0,0.358833 -0.109141,0.436566 -0.450077,0.815055 -0.53825,1.255917 -0.243238,1.216194 -0.83349,4.919206 -0.53825,6.100167 0.04103,0.164105 0.265003,0.218087 0.358834,0.358833 0.368034,0.552051 0.529049,1.242116 0.897083,1.794167 0.187662,0.281492 0.530005,0.436175 0.717667,0.717667 0.09712,0.145673 -0.120978,0.596689 0,0.717666 0.01794,0.01794 0.400697,0.137553 0.179417,0.358834 -0.915812,0.915811 -4.122531,1.299757 -5.382501,1.61475 -0.866393,0.216598 0.0089,0.08526 -0.53825,0.358833 -0.401652,0.200826 -1.178542,-0.109052 -1.61475,0 -0.230833,0.05771 -1.360413,0.433754 -1.61475,0.179417 -0.211445,-0.211445 -0.358833,-0.478445 -0.53825,-0.717667 z"
+             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.00157;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <circle
+             r="28.168419"
+             cy="78.584503"
+             cx="66.563591"
+             id="path1051"
+             style="fill:#ffffff;fill-opacity:1;stroke-width:2.51339;stroke-miterlimit:4;stroke-dasharray:none" />
+          <circle
+             style="fill:#ffffff;fill-opacity:1;stroke-width:2.51339;stroke-miterlimit:4;stroke-dasharray:none"
+             id="path1051-6"
+             cx="92.040756"
+             cy="80.199257"
+             r="28.168419" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
The currently used worldgourd logo looks like a duplicate from the lesser known plugin "WorldGuard". That should be fixed.